### PR TITLE
Close the scanner when context is done to prevent app from hanging

### DIFF
--- a/syslog/v3/server.go
+++ b/syslog/v3/server.go
@@ -278,7 +278,6 @@ loop:
 			break loop
 		}
 	}
-	scanCloser.closer.Close()
 
 	s.wait.Done()
 }

--- a/syslog/v3/server_bench_test.go
+++ b/syslog/v3/server_bench_test.go
@@ -2,6 +2,7 @@ package syslog
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"net"
 	"testing"
@@ -94,7 +95,7 @@ func BenchmarkTCPNoFormatting(b *testing.B) {
 	server.SetFormat(noopFormatter{})
 	server.SetHandler(handler)
 	server.ListenTCP("127.0.0.1:0")
-	server.Boot()
+	server.Boot(context.Background())
 	conn, _ := net.DialTimeout("tcp", server.listeners[0].Addr().String(), time.Second)
 	msg := []byte(exampleSyslog + "\n")
 	b.SetBytes(int64(len(msg)))

--- a/syslog/v3/servertls_test.go
+++ b/syslog/v3/servertls_test.go
@@ -1,6 +1,7 @@
 package syslog
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
@@ -61,7 +62,7 @@ func (s *ServerSuite) TestTLS(c *C) {
 	server.SetHandler(handler)
 	server.ListenTCPTLS("0.0.0.0:5143", getServerConfig())
 
-	server.Boot()
+	server.Boot(context.Background())
 	go func(server *Server) {
 		time.Sleep(100 * time.Millisecond)
 		conn, err := tls.Dial("tcp", "127.0.0.1:5143", getClientConfig())


### PR DESCRIPTION
Closing the scanner when the context is cancelled to prevent apps from hanging